### PR TITLE
bump 1.0.6

### DIFF
--- a/JShift.xcodeproj/project.pbxproj
+++ b/JShift.xcodeproj/project.pbxproj
@@ -391,7 +391,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ShinKawakami.JShift.JShift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -425,7 +425,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.5;
+				MARKETING_VERSION = 1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.ShinKawakami.JShift.JShift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary
- Update app version from 1.0.5 to 1.0.6 to address TestFlight's 90-day limit
- Build number remains at 1 as requested

## Test plan
- Verify version number is correctly updated in project configuration
- Build and test app functionality remains unchanged

close #8

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

  * アプリのマーケティング版番号を 1.0.6 に更新しました。
  * Debug/Release 両ビルドでバージョン表記を統一しました。
  * 機能面の変更や挙動の影響はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->